### PR TITLE
fix: fast-xml-parser の非推奨 XMLBuilder を fast-xml-builder パッケージに移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-n": "18.0.1",
     "eslint-plugin-promise": "7.3.0",
-    "fast-xml-parser": "5.6.0",
     "prettier": "3.8.3",
     "run-z": "2.1.0",
     "tsx": "4.22.2",
@@ -42,6 +41,7 @@
   },
   "packageManager": "pnpm@11.1.3",
   "dependencies": {
-    "fast-xml-builder": "^1.2.0"
+    "fast-xml-builder": "^1.2.0",
+    "fast-xml-parser": "5.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "tsx": "4.22.2",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.1.3"
+  "packageManager": "pnpm@11.1.3",
+  "dependencies": {
+    "fast-xml-builder": "^1.2.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      fast-xml-builder:
+        specifier: ^1.2.0
+        version: 1.2.0
     devDependencies:
       '@book000/eslint-config':
         specifier: 1.14.40

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       fast-xml-builder:
         specifier: ^1.2.0
         version: 1.2.0
+      fast-xml-parser:
+        specifier: 5.6.0
+        version: 5.6.0
     devDependencies:
       '@book000/eslint-config':
         specifier: 1.14.40
@@ -33,9 +36,6 @@ importers:
       eslint-plugin-promise:
         specifier: 7.3.0
         version: 7.3.0(eslint@10.4.0)
-      fast-xml-parser:
-        specifier: 5.6.0
-        version: 5.6.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+import { Builder as XMLBuilder } from 'fast-xml-builder'
+import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -101,15 +102,13 @@ async function main() {
   const builder = new XMLBuilder({
     ignoreAttributes: false,
   })
-  const feed: {
-    toString: () => string
-  } = builder.build(oldFeed)
+  const feed: string = builder.build(oldFeed)
 
   const outputDirectory = path.dirname(outputChangeLogPath)
   if (!fs.existsSync(outputDirectory)) {
     fs.mkdirSync(outputDirectory, { recursive: true })
   }
-  fs.writeFileSync(outputChangeLogPath, feed.toString())
+  fs.writeFileSync(outputChangeLogPath, feed)
 }
 
 ;(async () => {


### PR DESCRIPTION
## 概要

`fast-xml-parser` v5.8.0 で `XMLBuilder` が `@deprecated` となり、独立パッケージ `fast-xml-builder` の使用が推奨されるようになりました。本 PR はその移行作業を行います。

## 変更内容

### `src/main.ts`

- `import { XMLBuilder, XMLParser } from 'fast-xml-parser'` を分割:
  - `XMLBuilder` → `import { Builder as XMLBuilder } from 'fast-xml-builder'`
  - `XMLParser` → `import { XMLParser } from 'fast-xml-parser'`（変更なし）
- `builder.build()` の戻り値型を `{ toString: () => string }` から正確な `string` 型に修正
  - `fast-xml-builder` の `XMLBuilder.build()` は `string` を直接返すため、`.toString()` の呼び出しも不要になり除去
- `fs.writeFileSync(outputChangeLogPath, feed.toString())` → `fs.writeFileSync(outputChangeLogPath, feed)`

### `package.json`

- `fast-xml-builder@^1.2.0` を `dependencies` に追加
- `fast-xml-parser@5.6.0` を `devDependencies` から `dependencies` に移動
  - `src/main.ts` で実行時に `XMLParser` を import しているため、`dependencies` に配置するのが適切

### `pnpm-lock.yaml`

- `fast-xml-builder` および `fast-xml-parser` のロックファイルエントリを更新

## 背景

Renovate PR #1539 (`update dependency fast-xml-parser to v5.8.0`) で Node CI が失敗していました。エラー内容:

```
`XMLBuilder` is deprecated. Use npm package 'fast-xml-builder' instead @typescript-eslint/no-deprecated
```

本 PR により、`fast-xml-parser` を最新バージョンに更新した際もエラーが発生しなくなります。

## 確認事項

- [x] TypeScript コンパイルエラーなし (`tsc --noEmit`)
- [x] ESLint エラーなし
- [x] Prettier フォーマットチェック通過
- [x] `fast-xml-parser` と `fast-xml-builder` を両方 `dependencies` に配置（実行時依存として正しく管理）