### PR TITLE
fix: TypeScript v6 非推奨設定の削除と moduleResolution の更新

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "rootDir": "./src",
     "outDir": "./dist",
@@ -23,11 +23,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "types": ["node"]
   },


### PR DESCRIPTION
## 概要

TypeScript v6.0 の破壊的変更に対応するため、`tsconfig.json` の非推奨設定を修正します。

Fixes #1628

## 変更内容

### 問題

`tsconfig.json` に以下の非推奨設定が存在し、TypeScript v7.0 での互換性を失う可能性がありました:

1. `"moduleResolution": "Node"` — TS5107 警告をトリガー
2. `"baseUrl": "."` — TS5101 警告をトリガー
3. `"ignoreDeprecations": "6.0"` — TypeScript v7 では機能しない一時的な抑制設定

### 修正

- `"moduleResolution": "Node"` → `"bundler"` に変更（TypeScript v6 で CommonJS と公式にサポート）
- `"baseUrl": "."` を削除
- `"paths"` の `@/*` エイリアスを `"src/*"` から `"./src/*"` に更新（相対パス形式）
- `"ignoreDeprecations": "6.0"` を削除

## 確認事項

- [x] `pnpm lint:tsc` による TypeScript 型チェックが通ること
- [x] `pnpm lint` による全 Lint チェックが通ること