### PR TITLE
fix: fast-xml-builder の型定義バグによる lint:tsc 失敗を解消

### DIFF
--- a/patches/fast-xml-builder@1.2.0.patch
+++ b/patches/fast-xml-builder@1.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/fxb.d.cts b/lib/fxb.d.cts
+index ba98cb07aba1fbd55dd1c1066f1aaeaa877accae..cbd6309d87052697fa355319f5cdcf3fef2590b4 100644
+--- a/lib/fxb.d.cts
++++ b/lib/fxb.d.cts
+@@ -11,7 +11,7 @@ type Expression = unknown;
+  * the parent Matcher's internal state so it always reflects the current parser
+  * position with no copying or freezing.
+  */
+-class MatcherView {
++declare class MatcherView {
+   readonly separator: string;
+ 
+   /** Check if current path matches an Expression. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  fast-xml-builder@1.2.0: 4e156303b7800b16976f2d40c31e2372c42efa67e5eabf7e09377d0918b53bea
+
 importers:
 
   .:
     dependencies:
       fast-xml-builder:
         specifier: 1.2.0
-        version: 1.2.0
+        version: 1.2.0(patch_hash=4e156303b7800b16976f2d40c31e2372c42efa67e5eabf7e09377d0918b53bea)
       fast-xml-parser:
         specifier: 5.8.0
         version: 5.8.0
@@ -2334,7 +2337,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-builder@1.2.0:
+  fast-xml-builder@1.2.0(patch_hash=4e156303b7800b16976f2d40c31e2372c42efa67e5eabf7e09377d0918b53bea):
     dependencies:
       path-expression-matcher: 1.5.0
       xml-naming: 0.1.0
@@ -2342,7 +2345,7 @@ snapshots:
   fast-xml-parser@5.8.0:
     dependencies:
       '@nodable/entities': 2.1.1
-      fast-xml-builder: 1.2.0
+      fast-xml-builder: 1.2.0(patch_hash=4e156303b7800b16976f2d40c31e2372c42efa67e5eabf7e09377d0918b53bea)
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
       xml-naming: 0.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
   - '@book000/*'
+patchedDependencies:
+  fast-xml-builder@1.2.0: patches/fast-xml-builder@1.2.0.patch

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Builder as XMLBuilder } from 'fast-xml-builder'
+import XMLBuilder from 'fast-xml-builder'
 import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
 import path from 'node:path'


### PR DESCRIPTION
Closes #1649

## 概要

Node CI の `lint:tsc`(TypeScript 型チェック)が、`fast-xml-builder@1.2.0` 自身の型定義ファイル(`lib/fxb.d.cts`)のバグにより継続的に失敗していた問題を解消します。

## 原因

- `fast-xml-builder@1.2.0` の `lib/fxb.d.cts` にある `class MatcherView { ... }` がトップレベル宣言として `declare`/`export` 修飾子を欠いており、`.d.ts` ファイルの規約違反(`TS1046`)を起こしていた。上流の最新版(1.2.1・1.3.0)でも未修正。
- `src/main.ts` は `fast-xml-builder` を `import { Builder as XMLBuilder } from 'fast-xml-builder'` という名前付きインポートで読み込んでいたが、同パッケージは CommonJS の `export =` 形式のため `TS2616` も発生していた。

## 対応内容

- `pnpm patch` で `fast-xml-builder@1.2.0` の `lib/fxb.d.cts` にパッチを当て、`class MatcherView` に `declare` 修飾子を追加(`patches/fast-xml-builder@1.2.0.patch` 新規追加、`pnpm-workspace.yaml`/`pnpm-lock.yaml` を自動更新)
- `src/main.ts` の import を default import(`import XMLBuilder from 'fast-xml-builder'`)に変更(`esModuleInterop: true` により機能。実行時の呼び出し方法 `new XMLBuilder(...)` は変更なし)

`skipLibCheck` の追加や、非推奨 API(`fast-xml-parser` 組み込みの `XMLBuilder`)への差し戻しは行っていません。

## 将来リスクの扱い

`fast-xml-builder` 側で型定義が修正された場合、このパッチは不要になります。パッチの除去判断は本 Issue 専用の追跡 Issue を新規作成せず、通常の Renovate 依存更新 PR のレビュー時に行います。

## 検証

- `pnpm lint:tsc`(実際の CI スクリプト)が exit 0 で成功
- `pnpm lint`(prettier・eslint・tsc)がすべてエラーなく成功
- 変更ファイルは `patches/fast-xml-builder@1.2.0.patch`(新規)・`pnpm-workspace.yaml`・`pnpm-lock.yaml`・`src/main.ts` の 4 ファイルのみ

## 設計・計画資料

- Spec: https://github.com/book000/github-changelog-translator/issues/1649#issuecomment-4948050539
- Plan: https://github.com/book000/github-changelog-translator/issues/1649#issuecomment-4948075492
