### PR TITLE
chore: .worktreeinclude を追加し環境変数関連ファイルを除外

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.env.local
+.env.*.local


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規作成し、環境変数関連ファイルを Git Worktree 作成時にも引き継がれるよう設定しました。

## 変更内容

- `.worktreeinclude`（新規）: 以下のパターンを登録
  - `.env`
  - `.env.local`
  - `.env.*.local`

## 根拠

- `src/main.ts` で `GAS_URL` を `process.env` から直接取得しており、デフォルト値のないフォールバック無しの必須シークレットとして扱われている
- `CLAUDE.md` の「環境変数」節で `GAS_URL` は必須（必須）と明記されているが、ローカル用のテンプレート/サンプルファイルは提供されていない
- `CLAUDE.md` の「セキュリティ / 運用ルール」節: 「`GAS_URL` などの機密情報を含むファイルをコミットしない…機密は GitHub Actions の Secrets で管理する」
- `.gitignore` には標準的な dotenv 系エントリ（`.env`, `.env.development.local`, `.env.test.local`, `.env.production.local`, `.env.local`）が含まれている
- `.github/workflows/update-rss.yml` は CI 実行時に `GAS_URL: ${{ secrets.GAS_URL }}` を渡しており、`GAS_URL` がリポジトリにコミットされないことを裏付けている

## レビュー結果

- lite-review: 指摘事項なし（CLAUDE.md 準拠、バグ/正確性、コメント品質、セキュリティを確認）
- CI: 全チェック通過
- Copilot レビュー: フォーク PR かつ対象リポジトリへの書き込み権限がないため、レビュー依頼不可

## 関連

- https://github.com/book000/book000/issues/132
